### PR TITLE
drivers: interrupt_controller: for ipc interface

### DIFF
--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -1,3 +1,5 @@
+zephyr_include_directories(.)
+
 zephyr_sources_ifdef(CONFIG_ARCV2_INTERRUPT_UNIT    arcv2_irq_unit.c)
 zephyr_sources_ifdef(CONFIG_IOAPIC                  ioapic_intr.c)
 zephyr_sources_ifdef(CONFIG_LOAPIC                  loapic_intr.c system_apic.c)


### PR DESCRIPTION
   ipi add include header

Signed-off-by: yuanjiang.li <yuanjiang.li@unisoc.com>