### PR TITLE
drivers: wifi: Recycle rx buffer and update Wi-Fi command

### DIFF
--- a/drivers/wifi/uwp/wifi_cmdevt.h
+++ b/drivers/wifi/uwp/wifi_cmdevt.h
@@ -7,7 +7,7 @@
 #ifndef __WIFI_CMDEVT_H__
 #define __WIFI_CMDEVT_H__
 
-#include <net/wifi_mgmt.h>
+#include <net/wifimgr_drv.h>
 
 #define MAX_SSID_LEN (33) /* SSID end with 0 */
 #define MAX_KEY_LEN (128) /* FIXME: Max size 64 */
@@ -114,7 +114,7 @@ struct cmd_del_station {
 /* Command struct for sta. */
 struct cmd_scan {
 	struct trans_hdr trans_header;
-	u32_t channels; /* One bit for one channel. */
+	u32_t channels_2g; /* One bit for one 2.4G channel. */
 	u32_t flags;
 	u16_t ssid_len; /* Hidden ssid length. */
 	u8_t ssid[0]; /* FIXME: Invalid reservation. Hidden ssid.  */
@@ -192,12 +192,13 @@ struct event_new_station {
 int wifi_cmd_get_cp_info(struct wifi_priv *priv);
 int wifi_cmd_open(struct wifi_priv *priv);
 int wifi_cmd_close(struct wifi_priv *priv);
-int wifi_cmd_scan(struct wifi_priv *priv);
+int wifi_cmd_scan(struct wifi_priv *priv,
+		struct wifi_drv_scan_params *params);
 int wifi_cmd_connect(struct wifi_priv *priv,
-			    struct wifi_connect_req_params *params);
+			    struct wifi_drv_connect_params *params);
 int wifi_cmd_disconnect(struct wifi_priv *priv);
 int wifi_cmd_start_ap(struct wifi_priv *priv,
-		struct wifi_start_ap_req_params *params);
+		struct wifi_drv_start_ap_params *params);
 int wifi_cmd_stop_ap(struct wifi_priv *priv);
 int wifi_cmd_npi_send(int ictx_id, char *t_buf,
 		u32_t t_len, char *r_buf, u32_t *r_len);

--- a/drivers/wifi/uwp/wifi_ipc.c
+++ b/drivers/wifi/uwp/wifi_ipc.c
@@ -73,7 +73,7 @@ int wifi_ipc_send(int ch, int prio, void *data, int len, int offset)
 		return -1;
 	}
 	SYS_LOG_DBG("IPC Channel %d Send data:", ch);
-	memcpy(blk.addr + BLOCK_HEADROOM_SIZE + offset, data, len);
+	memcpy((char *)blk.addr + BLOCK_HEADROOM_SIZE + offset, data, len);
 
 	blk.length = len + offset;
 	ret = sblock_send(0, ch, prio, &blk);
@@ -100,4 +100,3 @@ int wifi_ipc_recv(int ch, u8_t *data, int *len, int offset)
 
 	return ret;
 }
-

--- a/drivers/wifi/uwp/wifi_main.h
+++ b/drivers/wifi/uwp/wifi_main.h
@@ -8,7 +8,6 @@
 #define __WIFI_MAIN_H_
 
 #include <zephyr.h>
-#include <net/wifi_mgmt.h>
 #include "wifi_cmdevt.h"
 #include "wifi_txrx.h"
 #include "wifi_ipc.h"
@@ -32,6 +31,10 @@ struct wifi_priv {
 	/* bool connected; */
 	bool opened;
 	bool initialized;
+	scan_result_cb_t scan_result_cb;
+	connect_cb_t connect_cb;
+	disconnect_cb_t disconnect_cb;
+	new_station_t new_station_cb;
 };
 
 static inline void uwp_save_addr_before_payload(u32_t payload, void *addr)

--- a/drivers/wifi/uwp/wifi_txrx.h
+++ b/drivers/wifi/uwp/wifi_txrx.h
@@ -338,5 +338,6 @@ int wifi_tx_cmd(void *data, int len);
 int wifi_txrx_init(struct wifi_priv *priv);
 int wifi_tx_empty_buf(int num);
 int wifi_tx_data(void *data, int len);
+int wifi_release_rx_buf(void);
 
 #endif /* __WIFI_TXRX_H__ */


### PR DESCRIPTION
Recycle rx buffer if not needed and match the lastest cmd from wifimgr.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>