### PR TITLE
arm: Placing the functions which holds __ramfunc into '.ramfunc'

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -347,6 +347,16 @@ SECTIONS
 
     __data_rom_start = LOADADDR(_DATA_SECTION_NAME);
 
+    SECTION_DATA_PROLOGUE(.ramfunc,,)
+        {
+        __ramfunc_ram_start = .;
+        KERNEL_INPUT_SECTION(.ramfunc)
+        KERNEL_INPUT_SECTION(".ramfunc.*")
+        __ramfunc_ram_end = .;
+        } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+    __ramfunc_rom_start = LOADADDR(.ramfunc);
+
 #include <linker/common-ram.ld>
 #include <linker/priv_stacks.ld>
 #include <linker/kobject.ld>

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -249,6 +249,11 @@ extern char _vector_end[];
 /* end address of image, used by newlib for the heap */
 extern char _end[];
 
+/* ramfunc sections */
+extern char __ramfunc_ram_start[];
+extern char __ramfunc_ram_end[];
+extern char __ramfunc_rom_start[];
+
 #ifdef CONFIG_CCM_BASE_ADDRESS
 extern char __ccm_data_rom_start[];
 extern char __ccm_start[];

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -113,6 +113,11 @@ do {                                                                    \
 
 #define __in_section_unique(seg) ___in_section(seg, __FILE__, __COUNTER__)
 
+/* Using this places a function in RAM instead of FLASH.
+ */
+#define __ramfunc	__attribute__((noinline))			\
+			__attribute__((long_call,section(".ramfunc")))
+
 #ifdef CONFIG_APPLICATION_MEMORY
 #define __kernel	__in_section_unique(kernel)
 #define __kernel_noinit	__in_section_unique(kernel_noinit)

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -167,6 +167,8 @@ void _data_copy(void)
 {
 	(void)memcpy(&__data_ram_start, &__data_rom_start,
 		 ((u32_t) &__data_ram_end - (u32_t) &__data_ram_start));
+	(void)memcpy(&__ramfunc_ram_start, &__ramfunc_rom_start,
+		 ((u32_t) &__ramfunc_ram_end - (u32_t) &__ramfunc_ram_start));
 #ifdef CONFIG_CCM_BASE_ADDRESS
 	(void)memcpy(&__ccm_data_start, &__ccm_data_rom_start,
 		 ((u32_t) &__ccm_data_end - (u32_t) &__ccm_data_start));


### PR DESCRIPTION
__ramfunc is an intrinsis of IAR, using this places a function in RAM
instead of Flash. Code that for example reprograms flash at runtime
can't execute from flash, in that case must placing code into flash.

This commit create a new section named '.ramfunc' in link scripts,
all functions has __ramfunc keyword saved in thats sections and
will load from flash to sram after the system booted.

Signed-off-by: qianfan Zhao <qianfanguijin@163.com>