### PR TITLE
drivers: wifi: Remove sram initialization

### DIFF
--- a/drivers/wifi/uwp/Kconfig.uwp
+++ b/drivers/wifi/uwp/Kconfig.uwp
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2018, UNISOC Incorporated
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
 menuconfig WIFI_UWP
 	bool "Unisoc uwp wifi driver support"
 	default n
@@ -7,9 +14,6 @@ menuconfig WIFI_UWP
 	select NET_L2_ETHERNET
 
 if WIFI_UWP
-config WIFI_UWP_USE_SRAM
-	bool "Wifi use sram"
-	default y
 
 config WIFI_UWP_MAX_RX_ADDR_NUM
 	int "Max rx addr num each time"


### PR DESCRIPTION
Remove sram initialization from driver.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>