### PR TITLE
drivers: wifi: Add ethernet_init in init_fn

### DIFF
--- a/drivers/wifi/uwp/wifi_main.c
+++ b/drivers/wifi/uwp/wifi_main.c
@@ -280,6 +280,8 @@ static void uwp_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	priv->iface = iface;
+
+	ethernet_init(iface);
 }
 
 static int wifi_tx_fill_msdu_dscr(struct wifi_priv *priv,


### PR DESCRIPTION
To use ethernet arp, add ethernet_init invoked.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>