### PR TITLE
drivers: wifi: Minor modification for logger

### DIFF
--- a/drivers/wifi/uwp/wifi_cmdevt.c
+++ b/drivers/wifi/uwp/wifi_cmdevt.c
@@ -7,7 +7,7 @@
 #include <logging/log.h>
 #define LOG_MODULE_NAME wifi_uwp
 #define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
-LOG_MODULE_DECLARE(LOG_MODULE_NAME)
+LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #include <zephyr.h>
 #include <string.h>

--- a/drivers/wifi/uwp/wifi_ipc.c
+++ b/drivers/wifi/uwp/wifi_ipc.c
@@ -7,7 +7,7 @@
 #include <logging/log.h>
 #define LOG_MODULE_NAME wifi_uwp
 #define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
-LOG_MODULE_DECLARE(LOG_MODULE_NAME)
+LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #include <zephyr.h>
 #include <string.h>

--- a/drivers/wifi/uwp/wifi_main.c
+++ b/drivers/wifi/uwp/wifi_main.c
@@ -8,7 +8,7 @@
 #include <logging/log.h>
 #define LOG_MODULE_NAME wifi_uwp
 #define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
-LOG_MODULE_REGISTER(LOG_MODULE_NAME)
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr.h>
 #include <kernel.h>

--- a/drivers/wifi/uwp/wifi_main.h
+++ b/drivers/wifi/uwp/wifi_main.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __WIFI_MAIN_H_
-#define __WIFI_MAIN_H_
+#ifndef __WIFI_MAIN_H__
+#define __WIFI_MAIN_H__
 
 #include <zephyr.h>
 #include "wifi_cmdevt.h"
@@ -62,4 +62,4 @@ int wifi_get_mac(u8_t *mac, int idx);
 /* struct netif *wifi_ifnet_get_interface(struct adapter *pAd,int ctx_id); */
 
 
-#endif /* __WIFI_MAIN_H_ */
+#endif /* __WIFI_MAIN_H__ */

--- a/drivers/wifi/uwp/wifi_txrx.c
+++ b/drivers/wifi/uwp/wifi_txrx.c
@@ -7,7 +7,7 @@
 #include <logging/log.h>
 #define LOG_MODULE_NAME wifi_uwp
 #define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
-LOG_MODULE_DECLARE(LOG_MODULE_NAME)
+LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #include <zephyr.h>
 #include <string.h>


### PR DESCRIPTION
Add semicolon at end of LOG_MODULE_REGISTER/
DELCARE macro.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>