### PR TITLE
drivers: wifi: Revert Wi-Fi Kconfig

### DIFF
--- a/drivers/wifi/Kconfig
+++ b/drivers/wifi/Kconfig
@@ -33,14 +33,6 @@ config WIFI_OFFLOAD
 	help
 	  Enable support for Full-MAC WiFi devices.
 
-config WIFI_STA_DRV_NAME
-	string "STA driver name"
-	default "WIFI_STA"
-
-config WIFI_AP_DRV_NAME
-	string "SoftAP driver name"
-	default "WIFI_AP"
-
 source "drivers/wifi/winc1500/Kconfig.winc1500"
 source "drivers/wifi/simplelink/Kconfig.simplelink"
 source "drivers/wifi/eswifi/Kconfig.eswifi"

--- a/drivers/wifi/uwp/Kconfig.uwp
+++ b/drivers/wifi/uwp/Kconfig.uwp
@@ -12,8 +12,17 @@ menuconfig WIFI_UWP
 	select NETWORKING
 	select NET_BUF
 	select NET_L2_ETHERNET
+	select NET_IPV4
 
 if WIFI_UWP
+
+config WIFI_STA_DRV_NAME
+	string "STA driver name"
+	default "WIFI_STA"
+
+config WIFI_AP_DRV_NAME
+	string "SoftAP driver name"
+	default "WIFI_AP"
 
 config WIFI_UWP_MAX_RX_ADDR_NUM
 	int "Max rx addr num each time"


### PR DESCRIPTION
1) Remove Wi-Fi driver name from external Kconfig.
2) Add Wi-Fi driver name in internal one.
3) Select NET_IPV4 when WIFI_UWP selected.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>