### PR TITLE
subsys: wifi: refactor led part of WiFi manager

### DIFF
--- a/subsys/wifi/CMakeLists.txt
+++ b/subsys/wifi/CMakeLists.txt
@@ -14,3 +14,4 @@ zephyr_sources_ifdef(
   )
 zephyr_sources_ifdef(CONFIG_WIFIMGR_CLI cli.c)
 zephyr_sources_ifdef(CONFIG_WIFIMGR_DHCPC dhcpc.c)
+zephyr_sources_ifdef(CONFIG_WIFIMGR_LED led.c)

--- a/subsys/wifi/Kconfig
+++ b/subsys/wifi/Kconfig
@@ -14,8 +14,8 @@ config WIFIMGR
 	select PTHREAD_IPC
 	select POSIX_MQUEUE
         help
-		Enable the WiFi Manager.
-		By default, WiFi manger is build as only a library.
+	  Enable the WiFi Manager.
+	  By default, WiFi manger is build as only a library.
 
 if WIFIMGR
 
@@ -24,8 +24,8 @@ config WIFIMGR_CLI
 	select SHELL
 	default y
 	help
-		A client that can interact with WiFi manger,
-		which can be ran from shell.
+	  A client that can interact with WiFi manger,
+	  which can be ran from shell.
 
 config WIFIMGR_DHCPC
 	bool "Enable DHCP client"
@@ -34,14 +34,35 @@ config WIFIMGR_DHCPC
 	select NET_DHCPV4
 	default y
 	help
-		Start DHCP client by WiFi manger.
+	  Start DHCP client by WiFi manger.
 
 config WIFIMGR_LED
 	bool "Enable LED indiction"
-	select LED
 	default n
+        depends on LED_UWP
 	help
-		Enable LED indiction of WiFi manger.
+	  Enable LED indiction of WiFi manger.
+
+config WIFIMGR_LED_NAME
+	string "LED device name"
+	default "led"
+        depends on WIFIMGR_LED
+        help
+          Specify the LED device name.
+
+config WIFIMGR_LED_STA
+	int "STA LED"
+	default 2
+        depends on WIFIMGR_LED
+        help
+          Specify the STA LED.
+
+config WIFIMGR_LED_AP
+	int "AP LED"
+	default 3
+        depends on WIFIMGR_LED
+        help
+          Specify the AP LED.
 
 module = WIFIMGR
 module-str = Log for wifi manager

--- a/subsys/wifi/ap.c
+++ b/subsys/wifi/ap.c
@@ -117,7 +117,6 @@ int wifi_manager_start_softap(void *handle)
 	struct wifi_manager *mgr = (struct wifi_manager *)handle;
 	struct wifimgr_config *conf = &mgr->ap_conf;
 	int ret;
-	struct device *led;
 
 	if (!strlen(conf->ssid)) {
 		wifimgr_err("no AP config!\n");
@@ -142,10 +141,7 @@ int wifi_manager_start_softap(void *handle)
 		return ret;
 	}
 
-	led = device_get_binding(WIFIMGR_LED_NAME);
-	if (led) {
-		led_on(led, WIFIMGR_LED_PIN1);
-	}
+	wifimgr_ap_led_on();
 
 	command_processor_unregister_sender(&mgr->prcs, WIFIMGR_CMD_START_AP);
 
@@ -161,7 +157,6 @@ int wifi_manager_stop_softap(void *handle)
 {
 	struct wifi_manager *mgr = (struct wifi_manager *)handle;
 	int ret;
-	struct device *led;
 
 	ret = wifi_drv_iface_stop_softap(mgr->ap_iface);
 	if (ret) {
@@ -169,10 +164,7 @@ int wifi_manager_stop_softap(void *handle)
 		return ret;
 	}
 
-	led = device_get_binding(WIFIMGR_LED_NAME);
-	if (led) {
-		led_off(led, WIFIMGR_LED_PIN1);
-	}
+	wifimgr_ap_led_off();
 
 	event_listener_remove_receiver(&mgr->lsnr, WIFIMGR_EVT_NEW_STATION);
 

--- a/subsys/wifi/cmd_prcs.c
+++ b/subsys/wifi/cmd_prcs.c
@@ -81,7 +81,7 @@ static void *command_processor(void *handle)
 	int prio;
 	int ret;
 
-	wifimgr_info("starting %s, pid=%p\n", __func__, pthread_self());
+	wifimgr_dbg("starting %s, pid=%p\n", __func__, pthread_self());
 
 	if (!prcs)
 		return NULL;
@@ -200,7 +200,7 @@ int wifi_manager_command_processor_init(struct cmd_processor *handle)
 		mq_close(prcs->mq);
 		return ret;
 	}
-	wifimgr_info("started %s, pid=%p\n", WIFIMGR_CMD_PROCESSOR,
+	wifimgr_dbg("started %s, pid=%p\n", WIFIMGR_CMD_PROCESSOR,
 	       prcs->pid);
 
 	return 0;

--- a/subsys/wifi/dhcpc.c
+++ b/subsys/wifi/dhcpc.c
@@ -22,7 +22,6 @@ static void wifimgr_dhcp_handler(struct net_mgmt_event_callback *cb,
 				 unsigned int mgmt_event, struct net_if *iface)
 {
 	int i = 0;
-	struct device *led;
 
 	if (mgmt_event != NET_EVENT_IPV4_ADDR_ADD)
 		return;
@@ -50,10 +49,7 @@ static void wifimgr_dhcp_handler(struct net_mgmt_event_callback *cb,
 		wifimgr_info("Router: %s\n",
 		       net_addr_ntop(AF_INET, gateway, buf, sizeof(buf)));
 
-		led = device_get_binding(WIFIMGR_LED_NAME);
-		if (led) {
-			led_on(led, WIFIMGR_LED_PIN3);
-		}
+		wifimgr_sta_led_on();
 	}
 }
 
@@ -73,7 +69,6 @@ void wifimgr_dhcp_start(void *handle)
 void wifimgr_dhcp_stop(void *handle)
 {
 	struct net_if *iface = (struct net_if *)handle;
-	struct device *led;
 
 	wifimgr_info("stop DHCP client\n");
 
@@ -81,8 +76,5 @@ void wifimgr_dhcp_stop(void *handle)
 
 	net_dhcpv4_stop(iface);
 
-	led = device_get_binding(WIFIMGR_LED_NAME);
-	if (led) {
-		led_off(led, WIFIMGR_LED_PIN3);
-	}
+	wifimgr_sta_led_off();
 }

--- a/subsys/wifi/evt_lsnr.c
+++ b/subsys/wifi/evt_lsnr.c
@@ -127,7 +127,7 @@ static void *event_listener(void *handle)
 	int prio;
 	int ret;
 
-	wifimgr_info("starting %s, pid=%p\n", __func__, pthread_self());
+	wifimgr_dbg("starting %s, pid=%p\n", __func__, pthread_self());
 
 	if (!lsnr)
 		return NULL;
@@ -247,7 +247,7 @@ int wifi_manager_event_listener_init(struct evt_listener *handle)
 		mq_close(lsnr->mq);
 		return ret;
 	}
-	wifimgr_info("started %s, pid=%p\n", WIFIMGR_EVT_LISTENER,
+	wifimgr_dbg("started %s, pid=%p\n", WIFIMGR_EVT_LISTENER,
 	       lsnr->evt_pid);
 
 	return 0;

--- a/subsys/wifi/led.c
+++ b/subsys/wifi/led.c
@@ -1,0 +1,60 @@
+/*
+ *@file
+ * @brief LED indication
+ */
+
+/*
+ * Copyright (c) 2018, Unisoc Communications Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "led.h"
+
+static int wifimgr_led_on(const char *name, int pin)
+{
+	struct device *led;
+	int ret = -1;
+
+	led = device_get_binding(name);
+
+	if (led) {
+		ret = led_on(led, pin);
+	}
+
+	return ret;
+}
+
+static int wifimgr_led_off(const char *name, int pin)
+{
+	struct device *led;
+	int ret = -1;
+
+	led = device_get_binding(name);
+
+	if (led) {
+		led_off(led, pin);
+	}
+
+	return ret;
+}
+
+int wifimgr_sta_led_on(void)
+{
+	return wifimgr_led_on(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_STA);
+}
+
+int wifimgr_ap_led_on(void)
+{
+	return wifimgr_led_on(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_AP);
+}
+
+int wifimgr_sta_led_off(void)
+{
+	return wifimgr_led_off(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_STA);
+}
+
+int wifimgr_ap_led_off(void)
+{
+	return wifimgr_led_off(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_AP);
+}

--- a/subsys/wifi/led.h
+++ b/subsys/wifi/led.h
@@ -1,5 +1,5 @@
 /*
- *@file
+ * @file
  * @brief LED lighting header
  */
 
@@ -10,22 +10,21 @@
  */
 
 
-#ifndef _WIFI_LED_H_
-#define _WIFI_LED_H_
+#ifndef _WIFIMGR_LED_H_
+#define _WIFIMGR_LED_H_
 
-#ifdef CONFIG_LED
-#define WIFIMGR_LED_NAME CONFIG_LED_DRV_NAME
-#define WIFIMGR_LED_PIN1 CONFIG_LED_PIN1
-#define WIFIMGR_LED_PIN3 CONFIG_LED_PIN3
+#include <led.h>
+
+#ifdef CONFIG_WIFIMGR_LED
+int wifimgr_sta_led_on(void);
+int wifimgr_sta_led_off(void);
+int wifimgr_ap_led_on(void);
+int wifimgr_ap_led_off(void);
 #else
-#define WIFIMGR_LED_NAME ""
-#define WIFIMGR_LED_PIN1 (0)
-#define WIFIMGR_LED_PIN3 (0)
+#define wifimgr_sta_led_on(...)
+#define wifimgr_sta_led_off(...)
+#define wifimgr_ap_led_on(...)
+#define wifimgr_ap_led_off(...)
 #endif
 
-#define WIFIMGR_LED_OFF_VALUE (1)
-#define WIFIMGR_LED_ON_VALUE (0)
-
-
-
-#endif /* _WIFI_LED_H_ */
+#endif

--- a/subsys/wifi/wifimgr.c
+++ b/subsys/wifi/wifimgr.c
@@ -198,7 +198,6 @@ static int wifi_manager_init(struct device *unused)
 	ARG_UNUSED(unused);
 
 	/*setlogmask(~(LOG_MASK(LOG_DEBUG))); */
-	wifimgr_info("WiFi manager start\n");
 	memset(mgr, 0, sizeof(struct wifi_manager));
 
 	ret = wifi_manager_event_listener_init(&mgr->lsnr);
@@ -213,6 +212,8 @@ static int wifi_manager_init(struct device *unused)
 	ret = wifi_manager_sm_init(mgr);
 	if (ret < 0)
 		wifimgr_err("failed to init WiFi state machine!\n");
+
+	wifimgr_info("WiFi manager started\n");
 
 	return ret;
 }

--- a/subsys/wifi/wifimgr.h
+++ b/subsys/wifi/wifimgr.h
@@ -15,8 +15,6 @@
 #include <net/wifimgr_drv.h>
 #include <net/wifimgr_api.h>
 
-#include <led.h>
-
 #include "os_adapter.h"
 #include "cmd_prcs.h"
 #include "evt_lsnr.h"
@@ -24,6 +22,7 @@
 #include "drv_iface.h"
 #include "api.h"
 #include "dhcpc.h"
+#include "led.h"
 
 #define WIFIMGR_DEV_NAME_STA	CONFIG_WIFI_STA_DRV_NAME
 #define WIFIMGR_DEV_NAME_AP	CONFIG_WIFI_AP_DRV_NAME


### PR DESCRIPTION
Use generic LED interace instead of GPIO.

Signed-off-by: Keguang Zhang <keguang.zhang@unisoc.com>