### PR TITLE
drivers: wifi: Remove delay from device init_func

### DIFF
--- a/drivers/wifi/uwp/wifi_cmdevt.c
+++ b/drivers/wifi/uwp/wifi_cmdevt.c
@@ -274,7 +274,7 @@ int wifi_cmd_get_cp_info(struct wifi_priv *priv)
 	cmd.mac[4] ^= 0x80;
 	memcpy(priv->wifi_dev[WIFI_DEV_AP].mac, cmd.mac, ETH_ALEN);
 
-	printk("	CP version: 0x%x\n", priv->cp_version);
+	LOG_INF("CP version: 0x%x\n", priv->cp_version);
 
 	return 0;
 }

--- a/drivers/wifi/uwp/wifi_main.c
+++ b/drivers/wifi/uwp/wifi_main.c
@@ -375,7 +375,7 @@ static void uwp_iface_init(struct net_if *iface)
 		return;
 	}
 
-	dev = iface->if_dev->dev;
+	dev = net_if_get_device(iface);
 	wifi_dev = get_wifi_dev_by_dev(dev);
 	if (!wifi_dev) {
 		LOG_ERR("Unable to find wifi dev by dev %p", dev);
@@ -463,7 +463,7 @@ static int uwp_iface_tx(struct net_if *iface, struct net_pkt *pkt)
 		return -EINVAL;
 	}
 
-	dev = iface->if_dev->dev;
+	dev = net_if_get_device(iface);
 	wifi_dev = get_wifi_dev_by_dev(dev);
 	if (!wifi_dev) {
 		LOG_ERR("Unable to find wifi dev by dev %p", dev);
@@ -576,7 +576,6 @@ static int uwp_init(struct device *dev)
 		wifi_txrx_init(priv);
 		wifi_irq_init();
 
-		k_sleep(400); /* FIXME: workaround */
 		ret = wifi_rf_init();
 		if (ret) {
 			LOG_ERR("wifi rf init failed.");


### PR DESCRIPTION
1) Remove k_sleep from uwp_init. If issue happened again, would add delay again.
2) Use net_if_get_device instead.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>