### PR TITLE
drivers: wifi: Remove irq relay initialize.

### DIFF
--- a/drivers/wifi/uwp/wifi_main.c
+++ b/drivers/wifi/uwp/wifi_main.c
@@ -574,7 +574,6 @@ static int uwp_init(struct device *dev)
 
 		wifi_cmdevt_init();
 		wifi_txrx_init(priv);
-		wifi_irq_init();
 
 		k_sleep(400); /* FIXME: workaround */
 		ret = wifi_rf_init();


### PR DESCRIPTION
Wi-Fi IRQ relay has been disabled by UWP hal.

Signed-off-by: Dong Xiang <dong.xiang@unisoc.com>