### PR TITLE
include: net: add new wifi driver api for hw_test

### DIFF
--- a/include/net/wifimgr_drv.h
+++ b/include/net/wifimgr_drv.h
@@ -81,6 +81,9 @@ struct wifi_drv_api{
 			new_station_t cb);
 	int (*stop_ap)(struct device *dev);
 	int (*del_station)(struct device *dev, u8_t *mac);
+	int (*hw_test)(struct device *dev, int ictx_id,
+		       char *t_buf, u32_t t_len, char *r_buf,
+		       u32_t *r_len)
 };
 
 #endif


### PR DESCRIPTION
This patch is to add new driver api for wifi hardware test.

Signed-off-by: Jessie.Xin <Jessie.Xin@unisoc.com>