### PR TITLE
subsys: wifi: use workqueue to offload event timeout handling

### DIFF
--- a/subsys/wifi/ap.c
+++ b/subsys/wifi/ap.c
@@ -19,6 +19,28 @@ LOG_MODULE_DECLARE(wifimgr);
 static int wifimgr_ap_stop(void *handle);
 static int wifimgr_ap_close(void *handle);
 
+void wifimgr_ap_event_timeout(wifimgr_work *work)
+{
+	struct wifimgr_state_machine *ap_sm =
+	    container_of(work, struct wifimgr_state_machine, work);
+	struct wifimgr_ctrl_cbs *cbs = wifimgr_get_ctrl_cbs();
+	unsigned int expected_evt;
+
+	/* Notify the external caller */
+	switch (ap_sm->cur_cmd) {
+	case WIFIMGR_CMD_DEL_STATION:
+		expected_evt = WIFIMGR_EVT_NEW_STATION;
+		wifimgr_err("[%s] timeout!\n",
+		       wifimgr_evt2str(expected_evt));
+
+		if (cbs && cbs->notify_del_station_timeout)
+			cbs->notify_del_station_timeout();
+		break;
+	default:
+		break;
+	}
+}
+
 static int wifimgr_ap_get_config(void *handle)
 {
 	struct wifi_manager *mgr = (struct wifi_manager *)handle;

--- a/subsys/wifi/os_adapter.h
+++ b/subsys/wifi/os_adapter.h
@@ -54,6 +54,11 @@
 typedef sys_snode_t wifimgr_snode_t;
 typedef sys_slist_t wifimgr_slist_t;
 
+typedef struct k_work wifimgr_work;
+
+#define wifimgr_init_work(...)	k_work_init(__VA_ARGS__)
+#define wifimgr_queue_work(...)	k_work_submit(__VA_ARGS__)
+
 /**
  * is_zero_ether_addr - Determine if give Ethernet address is all zeros.
  * @addr: Pointer to a six-byte array containing the Ethernet address

--- a/subsys/wifi/sm.h
+++ b/subsys/wifi/sm.h
@@ -28,10 +28,11 @@ enum wifimgr_sm_ap_state {
 };
 
 struct wifimgr_state_machine {
-	sem_t exclsem;		/* exclusive access to the struct */
+	wifimgr_work work;
 	unsigned int state;
 	unsigned int old_state;
 	unsigned int cur_cmd;	/* record the command under processing */
+	sem_t exclsem;		/* exclusive access to the struct */
 	timer_t timerid;	/* timer for event */
 };
 
@@ -61,4 +62,5 @@ bool is_ap_evt(unsigned int evt_id);
 int sm_ap_query(struct wifimgr_state_machine *ap_sm);
 void sm_ap_step_cmd(struct wifimgr_state_machine *ap_sm, unsigned int cmd_id);
 int sm_ap_init(struct wifimgr_state_machine *ap_sm);
+
 #endif

--- a/subsys/wifi/wifimgr.h
+++ b/subsys/wifi/wifimgr.h
@@ -113,7 +113,9 @@ void wifimgr_sm_step_evt(struct wifi_manager *mgr, unsigned int evt_id);
 void wifimgr_sm_step_back(struct wifi_manager *mgr, unsigned int evt_id);
 int wifimgr_low_level_init(struct wifi_manager *mgr, unsigned int cmd_id);
 
+void wifimgr_sta_event_timeout(wifimgr_work *work);
 void wifimgr_sta_init(void *handle);
+void wifimgr_ap_event_timeout(wifimgr_work *work);
 void wifimgr_ap_init(void *handle);
 
 #endif


### PR DESCRIPTION
Use workqueue to avoid the semaphore issue in POSIX timeout handling.

Signed-off-by: Keguang Zhang <keguang.zhang@unisoc.com>