### PR TITLE
include: net: fix build warning in wifi_drv_api

### DIFF
--- a/include/net/wifimgr_drv.h
+++ b/include/net/wifimgr_drv.h
@@ -83,7 +83,7 @@ struct wifi_drv_api{
 	int (*del_station)(struct device *dev, u8_t *mac);
 	int (*hw_test)(struct device *dev, int ictx_id,
 		       char *t_buf, u32_t t_len, char *r_buf,
-		       u32_t *r_len)
+		       u32_t *r_len);
 };
 
 #endif


### PR DESCRIPTION
This patch is to fix build warning in wifi_drv_api.

Signed-off-by: Jessie.Xin <Jessie.Xin@unisoc.com>