### PR TITLE
drivers: wifi: uwp: Unref net_buf if tx error happens

### DIFF
--- a/drivers/wifi/uwp/wifi_main.c
+++ b/drivers/wifi/uwp/wifi_main.c
@@ -535,12 +535,14 @@ static int uwp_iface_tx(struct net_if *iface, struct net_pkt *pkt)
 		if (data_len > max_len) {
 			LOG_ERR("Exceed max length %d data_len %d",
 					max_len, data_len);
+			net_buf_unref(frag);
 			return -EINVAL;
 		}
 
 		if (wifi_tx_data((void *)addr, data_len)) {
 			LOG_WRN("Send data failed.");
-			net_pkt_unref(pkt);
+			net_buf_unref(frag);
+			return -EIO;
 		}
 	}
 


### PR DESCRIPTION
Should unref net_buf rather than net_pkt because it's sending
net_buf one by one as of now. We add this unref if data_len
exceeds maximum value and tx fails.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>