### PR TITLE
drivers: wifi: uwp: Add more params in connect event

### DIFF
--- a/drivers/wifi/uwp/wifi_cmdevt.c
+++ b/drivers/wifi/uwp/wifi_cmdevt.c
@@ -609,7 +609,8 @@ static int wifi_evt_connect(struct wifi_device *wifi_dev, char *data, int len)
 	}
 
 	if (wifi_dev->connect_cb) {
-		wifi_dev->connect_cb(wifi_dev->iface, event->status);
+		wifi_dev->connect_cb(wifi_dev->iface, event->status,
+				event->bssid, event->primary_chan_num);
 	} else {
 		LOG_WRN("No connect callback.");
 	}

--- a/drivers/wifi/uwp/wifi_cmdevt.h
+++ b/drivers/wifi/uwp/wifi_cmdevt.h
@@ -187,6 +187,8 @@ struct event_scan_done {
 
 struct event_connect {
 	u8_t status;
+	u8_t bssid[ETH_ALEN];
+	u8_t primary_chan_num;
 } __packed;
 
 struct event_disconnect {


### PR DESCRIPTION
Wifimgr needs channel and BSSID from connect event.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>