### PR TITLE
subsys: wifi: refactor config and add params check for set_conf

### DIFF
--- a/subsys/wifi/api.h
+++ b/subsys/wifi/api.h
@@ -14,8 +14,8 @@
 
 int wifimgr_ctrl_iface_set_conf(char *iface_name, char *ssid, char *bssid,
 				char *passphrase, unsigned char band,
-				unsigned char channel,
-				unsigned char channel_width);
+				unsigned char channel, unsigned char ch_width,
+				char autorun);
 int wifimgr_ctrl_iface_get_conf(char *iface_name);
 int wifimgr_ctrl_iface_get_status(char *iface_name);
 int wifimgr_ctrl_iface_open(char *iface_name);

--- a/subsys/wifi/config.h
+++ b/subsys/wifi/config.h
@@ -15,34 +15,39 @@
 #include <settings/settings.h>
 
 #define WIFIMGR_SETTING_NAME_LEN	63
-#define WIFIMGR_SETTING_VAL_LEN		63
+#define WIFIMGR_SETTING_VAL_LEN		(((((WIFIMGR_SETTING_NAME_LEN) / 3) * 4) + 4) + 1)	/*Due to base64 encoding*/
 
+#define WIFIMGR_SETTING_NAME_AUTORUN		"autorun"
 #define WIFIMGR_SETTING_NAME_SSID		"ssid"
 #define WIFIMGR_SETTING_NAME_BSSID		"bssid"
 #define WIFIMGR_SETTING_NAME_PSK		"psk"
 #define WIFIMGR_SETTING_NAME_BAND		"band"
 #define WIFIMGR_SETTING_NAME_CHANNEL		"channel"
-#define WIFIMGR_SETTING_NAME_CHANNEL_WIDTH	"channel_width"
+#define WIFIMGR_SETTING_NAME_CHANNEL_WIDTH	"ch_width"
 
 #define WIFIMGR_SETTING_PATH		"wifimgr"
 #define WIFIMGR_SETTING_STA_PATH	"wifimgr/sta"
 #define WIFIMGR_SETTING_AP_PATH		"wifimgr/ap"
 
 struct wifimgr_settings_map {
+	enum settings_type type;
 	char name[WIFIMGR_SETTING_NAME_LEN + 1];
 	char *valptr;
-	char vallen;
-	enum settings_type type;
+	int vallen;
+	bool mask;
 };
 
 #ifdef CONFIG_WIFIMGR_CONFIG
 int wifimgr_config_init(void *handle);
-int wifimgr_load_config(void *handle, char *path);
-int wifimgr_save_config(void *handle, char *path);
+int wifimgr_config_load(void *handle, char *path);
+int wifimgr_settings_save(void *handle, char *path, bool clear);
+#define wifimgr_config_save(...)	wifimgr_settings_save(__VA_ARGS__, false)
+#define wifimgr_config_clear(...)	wifimgr_settings_save(__VA_ARGS__, true)
 #else
 #define wifimgr_config_init(...)
-#define wifimgr_load_config(...)
-#define wifimgr_save_config(...)
+#define wifimgr_config_load(...)
+#define wifimgr_config_save(...)
+#define wifimgr_config_clear(...)
 #endif
 
 #endif

--- a/subsys/wifi/drv_iface.c
+++ b/subsys/wifi/drv_iface.c
@@ -9,6 +9,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define LOG_LEVEL CONFIG_WIFIMGR_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_DECLARE(wifimgr);
+
 #include "wifimgr.h"
 
 int wifi_drv_iface_get_mac(void *iface, char *mac)
@@ -192,7 +196,7 @@ void wifi_drv_iface_new_station(void *iface, int status, char *mac)
 }
 
 int wifi_drv_iface_start_ap(void *iface, char *ssid, char *passwd,
-			    unsigned char channel, unsigned char channel_width)
+			    unsigned char channel, unsigned char ch_width)
 {
 	struct device *dev = net_if_get_device((struct net_if *)iface);
 	struct wifi_drv_api *drv_api = (struct wifi_drv_api *)dev->driver_api;
@@ -206,7 +210,7 @@ int wifi_drv_iface_start_ap(void *iface, char *ssid, char *passwd,
 	params.psk = passwd;
 	params.psk_length = strlen(passwd);
 	params.channel = channel;
-	params.channel_width = channel_width;
+	params.ch_width = ch_width;
 
 	return drv_api->start_ap(dev, &params, wifi_drv_iface_new_station);
 }

--- a/subsys/wifi/drv_iface.h
+++ b/subsys/wifi/drv_iface.h
@@ -24,7 +24,7 @@ int wifi_drv_iface_notify_ip(void *iface, char *ipaddr, char len);
 int wifi_drv_iface_open_softap(void *iface);
 int wifi_drv_iface_close_softap(void *iface);
 int wifi_drv_iface_start_ap(void *iface, char *ssid, char *passwd,
-			    unsigned char channel, unsigned char channel_width);
+			    unsigned char channel, unsigned char ch_width);
 int wifi_drv_iface_stop_ap(void *iface);
 int wifi_drv_iface_del_station(void *iface, char *mac);
 

--- a/subsys/wifi/wifimgr.h
+++ b/subsys/wifi/wifimgr.h
@@ -39,12 +39,13 @@
 #define E2S(x) case x: return #x;
 
 struct wifimgr_config {
+	char autorun;
 	char ssid[WIFIMGR_MAX_SSID_LEN + 1];
 	char bssid[WIFIMGR_ETH_ALEN];
 	char passphrase[WIFIMGR_MAX_PSPHR_LEN + 1];
 	unsigned char band;
 	unsigned char channel;
-	unsigned char channel_width;
+	unsigned char ch_width;
 };
 
 struct wifimgr_status {


### PR DESCRIPTION
- Use settings_str_from_bytes/settings_bytes_from_str
to handle MAC address.
- Add params check for set_conf
- Add autorun to config.

Signed-off-by: Keguang Zhang <keguang.zhang@unisoc.com>