### PR TITLE
drivers: wifi: uwp: Read all data in rx thread

### DIFF
--- a/drivers/wifi/uwp/wifi_cmdevt.c
+++ b/drivers/wifi/uwp/wifi_cmdevt.c
@@ -616,7 +616,7 @@ static int wifi_evt_scan_result(struct wifi_device *wifi_dev,
 	if (wifi_dev->scan_result_cb) {
 		wifi_dev->scan_result_cb(wifi_dev->iface, 0, &scan_result);
 	} else {
-		LOG_WRN("No scan_result callback.");
+		LOG_DBG("No scan_result callback.");
 	}
 
 	k_yield();

--- a/drivers/wifi/uwp/wifi_main.c
+++ b/drivers/wifi/uwp/wifi_main.c
@@ -369,10 +369,6 @@ static int uwp_mgmt_scan(struct device *dev,
 		return -EINVAL;
 	}
 
-	if (wifi_dev->scan_result_cb) {
-		return -EAGAIN;
-	}
-
 	wifi_dev->scan_result_cb = cb;
 
 	return wifi_cmd_scan(wifi_dev, params);

--- a/drivers/wifi/uwp/wifi_txrx.c
+++ b/drivers/wifi/uwp/wifi_txrx.c
@@ -190,15 +190,17 @@ static void rx_data_thread(void *param)
 		LOG_DBG("Wait for data.");
 		k_sem_take(&data_sem, K_FOREVER);
 
-		memset(addr, 0, RX_DATA_SIZE);
-		ret = wifi_ipc_recv(SMSG_CH_WIFI_DATA_NOR,
-				addr, &len, 0);
-		if (ret == 0) {
-			LOG_DBG("Receive data %p len %i",
-					addr, len);
-			wifi_data_process(priv, addr, len);
-		} else {
-			LOG_WRN("IPC recv data failed.");
+		while (1) {
+			memset(addr, 0, RX_DATA_SIZE);
+			ret = wifi_ipc_recv(SMSG_CH_WIFI_DATA_NOR,
+					addr, &len, 0);
+			if (ret == 0) {
+				LOG_DBG("Receive data %p len %i",
+						addr, len);
+				wifi_data_process(priv, addr, len);
+			} else {
+				break;
+			}
 		}
 	}
 }
@@ -214,15 +216,17 @@ static void rx_cmdevt_thread(void *param)
 		LOG_DBG("Wait for cmdevt.");
 		k_sem_take(&event_sem, K_FOREVER);
 
-		memset(addr, 0, RX_CMDEVT_SIZE);
-		ret = wifi_ipc_recv(SMSG_CH_WIFI_CTRL, addr, &len, 0);
-		if (ret == 0) {
-			LOG_DBG("Receive cmd/evt %p len %i",
-					addr, len);
+		while (1) {
+			memset(addr, 0, RX_CMDEVT_SIZE);
+			ret = wifi_ipc_recv(SMSG_CH_WIFI_CTRL, addr, &len, 0);
+			if (ret == 0) {
+				LOG_DBG("Receive cmd/evt %p len %i",
+						addr, len);
 
-			wifi_cmdevt_process(priv, addr, len);
-		} else {
-			LOG_WRN("IPC recv cmd/evt failed.");
+				wifi_cmdevt_process(priv, addr, len);
+			} else {
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
One semaphore triggers to read all data in rx thread,
in case that there is data left.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>