### PR TITLE
subsys: wifi: add STA and AP related macros

### DIFF
--- a/subsys/wifi/CMakeLists.txt
+++ b/subsys/wifi/CMakeLists.txt
@@ -3,21 +3,21 @@ zephyr_compile_options(
 
 zephyr_sources_ifdef(
   CONFIG_WIFIMGR
-  ap.c
   api.c
   autorun.c
   cmd_prcs.c
   drv_iface.c
   evt_lsnr.c
   sm.c
-  sta.c
   wifimgr.c
   )
+zephyr_sources_ifdef(CONFIG_WIFIMGR_AP ap.c)
 zephyr_sources_ifdef(CONFIG_WIFIMGR_CLI cli.c)
 zephyr_sources_ifdef(CONFIG_WIFIMGR_CONFIG_SAVING config.c)
-zephyr_sources_ifdef(CONFIG_WIFIMGR_PSK psk.c)
 zephyr_sources_ifdef(CONFIG_WIFIMGR_DHCPC dhcpc.c)
 zephyr_sources_ifdef(CONFIG_WIFIMGR_LED led.c)
+zephyr_sources_ifdef(CONFIG_WIFIMGR_PSK psk.c)
+zephyr_sources_ifdef(CONFIG_WIFIMGR_STA sta.c)
 
 if(CONFIG_WIFIMGR_PSK)
   zephyr_sources(psk.c)

--- a/subsys/wifi/Kconfig
+++ b/subsys/wifi/Kconfig
@@ -36,15 +36,6 @@ config WIFIMGR_CONFIG_SAVING
 	help
 	  Enable Saving & Cleaning WiFi Configuration.
 
-config WIFIMGR_DHCPC
-	bool "Enable DHCP client"
-	select NETWORKING
-	select NET_IPV4
-	select NET_DHCPV4
-	default y
-	help
-	  Start DHCP client by WiFi manger.
-
 config WIFIMGR_PSK
 	bool "Enable PSK calculation"
 	depends on MBEDTLS
@@ -67,12 +58,39 @@ config WIFIMGR_LED_NAME
         help
           Specify the LED device name.
 
+config WIFIMGR_STA
+	bool "Enable STA mode"
+	default n
+        help
+          Enable STA mode.
+
+config WIFIMGR_AP
+	bool "Enable AP mode"
+	default n
+        help
+          Enable AP mode.
+
+if WIFIMGR_STA
+
 config WIFIMGR_LED_STA
 	int "STA LED"
 	default 2
         depends on WIFIMGR_LED
         help
           Specify the STA LED.
+
+config WIFIMGR_DHCPC
+	bool "Enable DHCP client"
+	select NETWORKING
+	select NET_IPV4
+	select NET_DHCPV4
+	default y
+	help
+	  Start DHCP client by WiFi manger.
+
+endif # WIFIMGR_STA
+
+if WIFIMGR_AP
 
 config WIFIMGR_LED_AP
 	int "AP LED"
@@ -81,10 +99,12 @@ config WIFIMGR_LED_AP
         help
           Specify the AP LED.
 
+endif # WIFIMGR_AP
+
 module = WIFIMGR
 module-str = Log for wifi manager
 source "subsys/logging/Kconfig.template.log_config"
 
-endif # WiFi
+endif # WIFIMGR
 
 endmenu

--- a/subsys/wifi/api.c
+++ b/subsys/wifi/api.c
@@ -218,6 +218,7 @@ static int wifimgr_ctrl_iface_close(char *iface_name)
 	return wifimgr_ctrl_iface_send_cmd(cmd_id, NULL, 0);
 }
 
+#ifdef CONFIG_WIFIMGR_STA
 static int wifimgr_ctrl_iface_scan(void)
 {
 	return wifimgr_ctrl_iface_send_cmd(WIFIMGR_CMD_SCAN, NULL, 0);
@@ -232,7 +233,9 @@ static int wifimgr_ctrl_iface_disconnect(void)
 {
 	return wifimgr_ctrl_iface_send_cmd(WIFIMGR_CMD_DISCONNECT, NULL, 0);
 }
+#endif
 
+#ifdef CONFIG_WIFIMGR_AP
 static int wifimgr_ctrl_iface_start_ap(void)
 {
 	return wifimgr_ctrl_iface_send_cmd(WIFIMGR_CMD_START_AP, NULL, 0);
@@ -270,6 +273,7 @@ static int wifimgr_ctrl_iface_set_mac_acl(char subcmd, char *mac)
 	return wifimgr_ctrl_iface_send_cmd(WIFIMGR_CMD_SET_MAC_ACL, &set_acl,
 					   sizeof(set_acl));
 }
+#endif
 
 static const struct wifimgr_ctrl_ops wifimgr_ops = {
 	.set_conf = wifimgr_ctrl_iface_set_conf,
@@ -278,12 +282,16 @@ static const struct wifimgr_ctrl_ops wifimgr_ops = {
 	.get_status = wifimgr_ctrl_iface_get_status,
 	.open = wifimgr_ctrl_iface_open,
 	.close = wifimgr_ctrl_iface_close,
+#ifdef CONFIG_WIFIMGR_STA
 	.scan = wifimgr_ctrl_iface_scan,
 	.connect = wifimgr_ctrl_iface_connect,
 	.disconnect = wifimgr_ctrl_iface_disconnect,
+#endif
+#ifdef CONFIG_WIFIMGR_AP
 	.start_ap = wifimgr_ctrl_iface_start_ap,
 	.stop_ap = wifimgr_ctrl_iface_stop_ap,
 	.set_mac_acl = wifimgr_ctrl_iface_set_mac_acl,
+#endif
 };
 
 const

--- a/subsys/wifi/config.h
+++ b/subsys/wifi/config.h
@@ -17,7 +17,8 @@
 #include "os_adapter.h"
 
 #define WIFIMGR_SETTING_NAME_LEN	63
-#define WIFIMGR_SETTING_VAL_LEN		(((((WIFIMGR_SETTING_NAME_LEN) / 3) * 4) + 4) + 1)	/*Due to base64 encoding*/
+#define WIFIMGR_SETTING_VAL_LEN	\
+	(((((WIFIMGR_SETTING_NAME_LEN) / 3) * 4) + 4) + 1) /*base64 encoding*/
 
 #define WIFIMGR_SETTING_NAME_SSID		"ssid"
 #define WIFIMGR_SETTING_NAME_BSSID		"bssid"
@@ -45,8 +46,10 @@ int wifimgr_config_init(void *handle, char *path);
 void wifimgr_config_exit(char *path);
 int wifimgr_config_load(void *handle, char *path);
 int wifimgr_settings_save(void *handle, char *path, bool clear);
-#define wifimgr_config_save(...)	wifimgr_settings_save(__VA_ARGS__, false)
-#define wifimgr_config_clear(...)	wifimgr_settings_save(__VA_ARGS__, true)
+#define wifimgr_config_save(...) \
+	wifimgr_settings_save(__VA_ARGS__, false)
+#define wifimgr_config_clear(...) \
+	wifimgr_settings_save(__VA_ARGS__, true)
 #else
 #define wifimgr_config_init(...)
 #define wifimgr_config_exit(...)

--- a/subsys/wifi/drv_iface.c
+++ b/subsys/wifi/drv_iface.c
@@ -80,6 +80,7 @@ int wifi_drv_close(void *iface)
 	return drv_api->close(dev);
 }
 
+#ifdef CONFIG_WIFIMGR_STA
 static
 void wifi_drv_event_iface_scan_result(void *iface, int status,
 				      struct wifi_drv_scan_result_evt *entry)
@@ -209,7 +210,9 @@ int wifi_drv_notify_ip(void *iface, char *ipaddr, char len)
 
 	return drv_api->notify_ip(dev, ipaddr, len);
 }
+#endif
 
+#ifdef CONFIG_WIFIMGR_AP
 static void wifi_drv_event_new_station(void *iface, int status, char *mac)
 {
 	struct wifi_drv_new_station_evt new_sta;
@@ -293,3 +296,4 @@ int wifi_drv_set_mac_acl(void *iface, char subcmd, unsigned char acl_nr,
 
 	return drv_api->set_mac_acl(dev, subcmd, acl_nr, acl_mac_addrs);
 }
+#endif

--- a/subsys/wifi/evt_lsnr.c
+++ b/subsys/wifi/evt_lsnr.c
@@ -210,9 +210,9 @@ static void *evt_listener(void *handle)
 			/* Trigger state machine */
 			wifimgr_sm_evt_step(mgr, msg.evt_id, ret);
 		} else {
-			wifimgr_err("unexpected [%s] under %s!\n",
-				    wifimgr_evt2str(msg.evt_id),
-				    wifimgr_sts2str_evt(mgr, msg.evt_id));
+			wifimgr_warn("unexpected [%s] under %s!\n",
+				     wifimgr_evt2str(msg.evt_id),
+				     wifimgr_sts2str_evt(mgr, msg.evt_id));
 		}
 
 		free(msg.buf);

--- a/subsys/wifi/led.c
+++ b/subsys/wifi/led.c
@@ -11,7 +11,7 @@
 
 #include "led.h"
 
-static int wifimgr_led_on(const char *name, int pin)
+int wifimgr_led_on(const char *name, int pin)
 {
 	struct device *led;
 	int ret = -1;
@@ -25,7 +25,7 @@ static int wifimgr_led_on(const char *name, int pin)
 	return ret;
 }
 
-static int wifimgr_led_off(const char *name, int pin)
+int wifimgr_led_off(const char *name, int pin)
 {
 	struct device *led;
 	int ret = -1;
@@ -37,24 +37,4 @@ static int wifimgr_led_off(const char *name, int pin)
 	}
 
 	return ret;
-}
-
-int wifimgr_sta_led_on(void)
-{
-	return wifimgr_led_on(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_STA);
-}
-
-int wifimgr_ap_led_on(void)
-{
-	return wifimgr_led_on(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_AP);
-}
-
-int wifimgr_sta_led_off(void)
-{
-	return wifimgr_led_off(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_STA);
-}
-
-int wifimgr_ap_led_off(void)
-{
-	return wifimgr_led_off(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_AP);
 }

--- a/subsys/wifi/led.h
+++ b/subsys/wifi/led.h
@@ -15,10 +15,22 @@
 #include <led.h>
 
 #ifdef CONFIG_WIFIMGR_LED
-int wifimgr_sta_led_on(void);
-int wifimgr_sta_led_off(void);
-int wifimgr_ap_led_on(void);
-int wifimgr_ap_led_off(void);
+int wifimgr_led_on(const char *name, int pin);
+int wifimgr_led_off(const char *name, int pin);
+#ifdef CONFIG_WIFIMGR_STA
+#define wifimgr_sta_led_on(...) \
+	wifimgr_led_on(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_STA)
+
+#define wifimgr_sta_led_off(...) \
+	wifimgr_led_off(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_STA)
+#endif
+#ifdef CONFIG_WIFIMGR_AP
+#define wifimgr_ap_led_on(...) \
+	wifimgr_led_on(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_AP)
+
+#define wifimgr_ap_led_off(...) \
+	wifimgr_led_off(CONFIG_WIFIMGR_LED_NAME, CONFIG_WIFIMGR_LED_AP)
+#endif
 #else
 #define wifimgr_sta_led_on(...)
 #define wifimgr_sta_led_off(...)

--- a/subsys/wifi/os_adapter.h
+++ b/subsys/wifi/os_adapter.h
@@ -49,9 +49,11 @@
 #define wifimgr_slist_peek_next(node)		sys_slist_peek_next(node)
 #define wifimgr_slist_prepend(list, node)	sys_slist_prepend(list, node)
 #define wifimgr_slist_append(list, node)	sys_slist_append(list, node)
-#define wifimgr_slist_merge(list_a, list_b)	sys_slist_merge_slist(list_a, list_b)
+#define wifimgr_slist_merge(list_a, list_b) \
+	sys_slist_merge_slist(list_a, list_b)
 #define wifimgr_slist_remove_first(list)	sys_slist_get(list)
-#define wifimgr_slist_remove(list, node)	sys_slist_find_and_remove(list, node)
+#define wifimgr_slist_remove(list, node) \
+	sys_slist_find_and_remove(list, node)
 
 typedef sys_snode_t wifimgr_snode_t;
 typedef sys_slist_t wifimgr_slist_t;

--- a/subsys/wifi/wifimgr.c
+++ b/subsys/wifi/wifimgr.c
@@ -13,6 +13,8 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(wifimgr);
 
+#if defined(CONFIG_WIFIMGR_STA) || defined(CONFIG_WIFIMGR_AP)
+
 #include <init.h>
 #include <shell/shell.h>
 
@@ -29,19 +31,20 @@ static int wifimgr_init(struct device *unused)
 
 	/*setlogmask(~(LOG_MASK(LOG_DEBUG))); */
 	memset(mgr, 0, sizeof(struct wifi_manager));
-
+#ifdef CONFIG_WIFIMGR_STA
 	ret = wifimgr_sta_init(mgr);
 	if (ret) {
 		wifimgr_err("failed to init WiFi STA!\n");
 		goto err;
 	}
-
+#endif
+#ifdef CONFIG_WIFIMGR_AP
 	ret = wifimgr_ap_init(mgr);
 	if (ret) {
 		wifimgr_err("failed to init WiFi AP!\n");
 		goto err;
 	}
-
+#endif
 	ret = wifimgr_evt_listener_init(&mgr->lsnr);
 	if (ret) {
 		wifimgr_err("failed to init WiFi event listener!\n");
@@ -60,9 +63,14 @@ static int wifimgr_init(struct device *unused)
 err:
 	wifimgr_cmd_processor_exit(&mgr->prcs);
 	wifimgr_evt_listener_exit(&mgr->lsnr);
+#ifdef CONFIG_WIFIMGR_AP
 	wifimgr_ap_exit(mgr);
+#endif
+#ifdef CONFIG_WIFIMGR_STA
 	wifimgr_sta_exit(mgr);
+#endif
 	return ret;
 }
 
 SYS_INIT(wifimgr_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+#endif


### PR DESCRIPTION
Add STA and AP related macros to enable
building each one separately.

Signed-off-by: Keguang Zhang <keguang.zhang@unisoc.com>