### PR TITLE
drivers: wifi: uwp: Keep all event callbacks

### DIFF
--- a/drivers/wifi/uwp/wifi_cmdevt.c
+++ b/drivers/wifi/uwp/wifi_cmdevt.c
@@ -19,7 +19,7 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #define RECV_BUF_SIZE (128)
 #define GET_STA_BUF_SIZE (12)
-#define ALL_2_4_GHZ_CHANNELS (0X3FFF)
+#define ALL_2_4_GHZ_CHANNELS (0x3FFF)
 #define CHANNEL_2_4_GHZ_BIT(n) (1 << (n - 1))
 
 extern struct wifi_priv uwp_wifi_ap_priv;
@@ -134,14 +134,14 @@ int wifi_cmd_scan(struct wifi_device *wifi_dev,
 			return -ENOMEM;
 		}
 
-		if (channel == 0) { /* All 2.4GH channel */
+		if (channel == 0) { /* All 2.4GHz channel */
 			cmd->channels_2g = ALL_2_4_GHZ_CHANNELS;
 		} else { /* One channel */
 			cmd->channels_2g = CHANNEL_2_4_GHZ_BIT(channel);
 		}
 		break;
 	case WIFI_BAND_5G:
-		if (channel == 0) { /* All 5GHZ channel */
+		if (channel == 0) { /* All 5GHz channel */
 			cmd_len +=  sizeof(channels_5g_scan_table);
 
 			cmd = k_malloc(cmd_len);

--- a/drivers/wifi/uwp/wifi_main.c
+++ b/drivers/wifi/uwp/wifi_main.c
@@ -184,23 +184,6 @@ static int uwp_mgmt_close(struct device *dev)
 		wifi_release_rx_buf();
 	}
 
-	/* Flush all callbacks */
-	if (wifi_dev->new_station_cb) {
-		wifi_dev->new_station_cb = NULL;
-	}
-
-	if (wifi_dev->scan_result_cb) {
-		wifi_dev->scan_result_cb = NULL;
-	}
-
-	if (wifi_dev->connect_cb) {
-		wifi_dev->connect_cb = NULL;
-	}
-
-	if (wifi_dev->disconnect_cb) {
-		wifi_dev->disconnect_cb = NULL;
-	}
-
 	return 0;
 }
 
@@ -226,10 +209,6 @@ static int uwp_mgmt_start_ap(struct device *dev,
 		return -EINVAL;
 	}
 
-	if (wifi_dev->new_station_cb) {
-		return -EAGAIN;
-	}
-
 	wifi_dev->new_station_cb = cb;
 
 	return wifi_cmd_start_ap(wifi_dev, params);
@@ -253,10 +232,6 @@ static int uwp_mgmt_stop_ap(struct device *dev)
 		LOG_WRN("Improper mode %d to stop_ap.",
 				wifi_dev->mode);
 		return -EINVAL;
-	}
-
-	if (wifi_dev->new_station_cb) {
-		wifi_dev->new_station_cb = NULL;
 	}
 
 	return wifi_cmd_stop_ap(wifi_dev);
@@ -380,7 +355,7 @@ static int uwp_mgmt_get_station(struct device *dev,
 {
 	struct wifi_device *wifi_dev;
 
-	if (!dev) {
+	if (!dev || !rssi) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
1) Do not drop event callbacks.
2) Allow a command which already has corresponding callback.
2) Correct some typos.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>