### PR TITLE
ext: hal: unisoc: Rename uwp5661 to uwp.

### DIFF
--- a/ext/hal/Kconfig
+++ b/ext/hal/Kconfig
@@ -36,6 +36,6 @@ source "ext/hal/st/lib/Kconfig"
 
 source "ext/hal/ti/simplelink/Kconfig"
 
-source "ext/hal/unisoc/uwp5661/Kconfig"
+source "ext/hal/unisoc/uwp/Kconfig"
 
 endmenu

--- a/ext/hal/unisoc/CMakeLists.txt
+++ b/ext/hal/unisoc/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_subdirectory(uwp5661)
+add_subdirectory(uwp)


### PR DESCRIPTION
The unisoc hal used to handle uwp series SoCs.

Signed-off-by: Dong Xiang <dong.xiang@unisoc.com>