### PR TITLE
soc: uniso_uwp: set clock to 320M

### DIFF
--- a/soc/arm/unisoc_uwp/uwp566x/Kconfig.defconfig.uwp5662
+++ b/soc/arm/unisoc_uwp/uwp566x/Kconfig.defconfig.uwp5662
@@ -14,6 +14,6 @@ config NUM_IRQS
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
-	default 416000000
+	default 320000000
 
 endif # SOC_UWP5662


### PR DESCRIPTION
set clock to 320M

Signed-off-by: baoleiyuan <baolei.yuan@unisoc.com>