### PR TITLE
subsys: wifi: use dedicated workqueue for timeout and autorun

### DIFF
--- a/subsys/wifi/CMakeLists.txt
+++ b/subsys/wifi/CMakeLists.txt
@@ -4,7 +4,6 @@ zephyr_compile_options(
 zephyr_sources_ifdef(
   CONFIG_WIFIMGR
   api.c
-  autorun.c
   cmd_prcs.c
   ctrl_iface.c
   drv_iface.c
@@ -15,6 +14,7 @@ zephyr_sources_ifdef(
   wifimgr.c
   )
 zephyr_sources_ifdef(CONFIG_WIFIMGR_AP ap.c)
+zephyr_sources_ifdef(CONFIG_WIFIMGR_AUTORUN autorun.c)
 zephyr_sources_ifdef(CONFIG_WIFIMGR_CLI cli.c)
 zephyr_sources_ifdef(CONFIG_WIFIMGR_CONFIG_SAVING config.c)
 zephyr_sources_ifdef(CONFIG_WIFIMGR_DHCPC dhcpc.c)

--- a/subsys/wifi/Kconfig
+++ b/subsys/wifi/Kconfig
@@ -28,6 +28,14 @@ config WIFIMGR_CLI
 	  A client that can interact with WiFi manger,
 	  which can be ran from shell.
 
+config WIFIMGR_AUTORUN
+	bool "WiFi Manager Autorun"
+	select SHELL
+	select NEWLIB_LIBC
+	default n
+	help
+	  A example program that can autorun WiFi manger.
+
 config WIFIMGR_CONFIG_SAVING
 	bool "Enable Saving Config"
 	select FCB

--- a/subsys/wifi/autorun.c
+++ b/subsys/wifi/autorun.c
@@ -20,11 +20,10 @@ LOG_MODULE_DECLARE(wifimgr);
 
 #include "wifimgr.h"
 
-/*#define WIFIMGR_AUTORUN_PRIORITY       91*/
-
 #ifdef CONFIG_WIFIMGR_STA
 #define WIFIMGR_AUTORUN_STA_RETRY	(3)
-wifimgr_work sta_work;
+K_THREAD_STACK_DEFINE(wifimgr_sta_autowq_stack, WIFIMGR_WORKQUEUE_STACK_SIZE);
+struct wifimgr_delayed_work *sta_autowork;
 timer_t sta_autorun_timerid;
 struct wifi_config sta_config;
 struct wifi_status sta_status;
@@ -32,7 +31,8 @@ static bool sta_connected;
 #endif
 
 #ifdef CONFIG_WIFIMGR_AP
-wifimgr_work ap_work;
+K_THREAD_STACK_DEFINE(wifimgr_ap_autowq_stack, WIFIMGR_WORKQUEUE_STACK_SIZE);
+struct wifimgr_delayed_work *ap_autowork;
 timer_t ap_autorun_timerid;
 struct wifi_config ap_config;
 struct wifi_status ap_status;
@@ -166,6 +166,35 @@ exit:
 out:
 	return;
 }
+
+int wifimgr_sta_autorun_init(void *handle)
+{
+	int ret;
+
+	sta_autowork = (struct wifimgr_delayed_work *)handle;
+	wifimgr_init_work(&sta_autowork->work, (void *)wifimgr_autorun_sta);
+	ret = wifimgr_timer_init(sta_autowork, wifimgr_timeout,
+				 &sta_autorun_timerid);
+	if (ret < 0)
+		wifimgr_err("failed to init STA autorun!\n");
+	wifimgr_create_workqueue(&sta_autowork->wq, wifimgr_sta_autowq_stack);
+
+	wifi_register_connection_notifier(wifimgr_autorun_notify_connect);
+	wifi_register_disconnection_notifier(wifimgr_autorun_notify_disconnect);
+
+	/* Set timer for the first run */
+	ret = wifimgr_timer_start(sta_autorun_timerid, 1);
+	if (ret < 0) {
+		wifimgr_err("failed to start STA autorun!\n");
+		wifi_unregister_connection_notifier
+		    (wifimgr_autorun_notify_connect);
+		wifi_unregister_disconnection_notifier
+		    (wifimgr_autorun_notify_disconnect);
+	}
+	sta_config.autorun = 60;
+
+	return ret;
+}
 #endif
 
 #ifdef CONFIG_WIFIMGR_AP
@@ -227,36 +256,17 @@ exit:
 }
 #endif
 
-int wifimgr_autorun_init(void)
+int wifimgr_ap_autorun_init(void *handle)
 {
 	int ret;
-#ifdef CONFIG_WIFIMGR_STA
-	wifimgr_init_work(&sta_work, (void *)wifimgr_autorun_sta);
-	ret = wifimgr_timer_init(&sta_work, wifimgr_timeout,
-				 &sta_autorun_timerid);
-	if (ret < 0)
-		wifimgr_err("failed to init STA autorun!\n");
 
-	wifi_register_connection_notifier(wifimgr_autorun_notify_connect);
-	wifi_register_disconnection_notifier(wifimgr_autorun_notify_disconnect);
-
-	/* Set timer for the first run */
-	ret = wifimgr_timer_start(sta_autorun_timerid, 1);
-	if (ret < 0) {
-		wifimgr_err("failed to start STA autorun!\n");
-		wifi_unregister_connection_notifier
-		    (wifimgr_autorun_notify_connect);
-		wifi_unregister_disconnection_notifier
-		    (wifimgr_autorun_notify_disconnect);
-	}
-	sta_config.autorun = 60;
-#endif
-#ifdef CONFIG_WIFIMGR_AP
-	wifimgr_init_work(&ap_work, (void *)wifimgr_autorun_ap);
-	ret = wifimgr_timer_init(&ap_work, wifimgr_timeout,
+	ap_autowork = (struct wifimgr_delayed_work *)handle;
+	wifimgr_init_work(&ap_autowork->work, (void *)wifimgr_autorun_ap);
+	ret = wifimgr_timer_init(ap_autowork, wifimgr_timeout,
 				 &ap_autorun_timerid);
 	if (ret < 0)
 		wifimgr_err("failed to init AP autorun!\n");
+	wifimgr_create_workqueue(&ap_autowork->wq, wifimgr_ap_autowq_stack);
 
 	wifimgr_register_new_station_notifier
 	    (wifimgr_autorun_notify_new_station);
@@ -271,7 +281,7 @@ int wifimgr_autorun_init(void)
 		wifimgr_unregister_station_leave_notifier
 		    (wifimgr_autorun_notify_station_leave);
 	}
-#endif
+
 	return ret;
 }
 

--- a/subsys/wifi/os_adapter.h
+++ b/subsys/wifi/os_adapter.h
@@ -45,10 +45,17 @@
 #define malloc(size)		k_malloc(size)
 #define free(ptr)		k_free(ptr)
 
+#define WIFIMGR_WORKQUEUE_STACK_SIZE	1024
+typedef struct k_work_q wifimgr_workqueue;
 typedef struct k_work wifimgr_work;
 
 #define wifimgr_init_work(...)	k_work_init(__VA_ARGS__)
-#define wifimgr_queue_work(...)	k_work_submit(__VA_ARGS__)
+#define wifimgr_queue_work(...)	k_work_submit_to_queue(__VA_ARGS__)
+#define wifimgr_create_workqueue(work_q, work_q_stack)		\
+	k_work_q_start(work_q, work_q_stack,			\
+		       K_THREAD_STACK_SIZEOF(work_q_stack),	\
+		       CONFIG_SYSTEM_WORKQUEUE_PRIORITY - 1)
+
 
 typedef sys_snode_t wifimgr_snode_t;
 typedef sys_slist_t wifimgr_slist_t;

--- a/subsys/wifi/sm.c
+++ b/subsys/wifi/sm.c
@@ -520,9 +520,9 @@ int wifimgr_sm_init(struct wifimgr_state_machine *sm, void *work_handler)
 	int ret;
 
 	sem_init(&sm->exclsem, 0, 1);
-	wifimgr_init_work(&sm->work, work_handler);
+	wifimgr_init_work(&sm->dwork.work, work_handler);
 
-	ret = wifimgr_timer_init(&sm->work, wifimgr_timeout, &sm->timerid);
+	ret = wifimgr_timer_init(&sm->dwork, wifimgr_timeout, &sm->timerid);
 	if (ret < 0)
 		wifimgr_err("failed to init WiFi timer! %d\n", ret);
 

--- a/subsys/wifi/sm.h
+++ b/subsys/wifi/sm.h
@@ -32,13 +32,18 @@ enum wifimgr_sm_ap_state {
 	WIFIMGR_SM_AP_STARTED,
 };
 
-struct wifimgr_state_machine {
+struct wifimgr_delayed_work {
+	wifimgr_workqueue wq;
 	wifimgr_work work;
+} dwork;
+
+struct wifimgr_state_machine {
+	sem_t exclsem;			/* exclusive access to the struct */
+	timer_t timerid;		/* timer for event */
+	struct wifimgr_delayed_work dwork;
 	unsigned int state;
 	unsigned int old_state;
-	unsigned int cur_cmd;	/* record the command under processing */
-	sem_t exclsem;		/* exclusive access to the struct */
-	timer_t timerid;	/* timer for event */
+	unsigned int cur_cmd;		/* record the command under processing */
 };
 
 const char *sta_sts2str(int state);

--- a/subsys/wifi/timer.c
+++ b/subsys/wifi/timer.c
@@ -11,12 +11,13 @@
 
 
 #include "os_adapter.h"
+#include "sm.h"
 
 void wifimgr_timeout(void *sival_ptr)
 {
-	wifimgr_work *work = (wifimgr_work *)sival_ptr;
+	struct wifimgr_delayed_work *dwork = (struct wifimgr_delayed_work *)sival_ptr;
 
-	wifimgr_queue_work(work);
+	wifimgr_queue_work(&dwork->wq, &dwork->work);
 }
 
 int wifimgr_timer_start(timer_t timerid, unsigned int sec)
@@ -56,13 +57,13 @@ int wifimgr_interval_timer_start(timer_t timerid, unsigned int sec,
 	return ret;
 }
 
-int wifimgr_timer_init(wifimgr_work *work, void *sighand, timer_t *timerid)
+int wifimgr_timer_init(struct wifimgr_delayed_work *dwork, void *sighand, timer_t *timerid)
 {
 	struct sigevent toevent;
 	int ret;
 
 	/* Create a POSIX timer to handle timeouts */
-	toevent.sigev_value.sival_ptr = work;
+	toevent.sigev_value.sival_ptr = dwork;
 	toevent.sigev_notify = SIGEV_SIGNAL;
 	toevent.sigev_notify_function = sighand;
 	toevent.sigev_notify_attributes = NULL;

--- a/subsys/wifi/timer.h
+++ b/subsys/wifi/timer.h
@@ -13,6 +13,7 @@
 #define _WIFI_TIMER_H_
 
 #include "os_adapter.h"
+#include "sm.h"
 
 #define wifimgr_timer_stop(timerid) wifimgr_timer_start(timerid, 0)
 
@@ -20,7 +21,7 @@ void wifimgr_timeout(void *sival_ptr);
 int wifimgr_timer_start(timer_t timerid, unsigned int sec);
 int wifimgr_interval_timer_start(timer_t timerid, unsigned int sec,
 				 unsigned int interval_sec);
-int wifimgr_timer_init(wifimgr_work *work, void *sighand, timer_t *timerid);
+int wifimgr_timer_init(struct wifimgr_delayed_work *dwork, void *sighand, timer_t *timerid);
 int wifimgr_timer_release(timer_t timerid);
 
 #endif

--- a/subsys/wifi/wifimgr.c
+++ b/subsys/wifi/wifimgr.c
@@ -43,21 +43,24 @@ static int wifimgr_init(struct device *unused)
 		wifimgr_err("failed to init WiFi command processor!\n");
 		goto err;
 	}
-#ifdef CONFIG_WIFIMGR_STA
+
 	ret = wifimgr_sta_init(mgr);
 	if (ret) {
 		wifimgr_err("failed to init WiFi STA!\n");
 		goto err;
 	}
-#endif
-#ifdef CONFIG_WIFIMGR_AP
+
 	ret = wifimgr_ap_init(mgr);
 	if (ret) {
 		wifimgr_err("failed to init WiFi AP!\n");
 		goto err;
 	}
-#endif
-	ret = wifimgr_autorun_init();
+
+	ret = wifimgr_sta_autorun_init(&mgr->sta_autowork);
+	if (ret)
+		wifimgr_err("failed to init WiFi autorun!\n");
+
+	ret = wifimgr_ap_autorun_init(&mgr->ap_autowork);
 	if (ret)
 		wifimgr_err("failed to init WiFi autorun!\n");
 
@@ -67,12 +70,8 @@ static int wifimgr_init(struct device *unused)
 err:
 	wifimgr_cmd_processor_exit(&mgr->prcs);
 	wifimgr_evt_listener_exit(&mgr->lsnr);
-#ifdef CONFIG_WIFIMGR_AP
 	wifimgr_ap_exit(mgr);
-#endif
-#ifdef CONFIG_WIFIMGR_STA
 	wifimgr_sta_exit(mgr);
-#endif
 	return ret;
 }
 

--- a/subsys/wifi/wifimgr.h
+++ b/subsys/wifi/wifimgr.h
@@ -79,6 +79,7 @@ struct wifi_manager {
 	struct wifi_rtt_request sta_rtt_req;
 	struct wifi_rtt_response sta_rtt_resp;
 	struct wifimgr_ctrl_iface sta_ctrl;
+	struct wifimgr_delayed_work sta_autowork;
 
 	union wifi_capa ap_capa;
 	struct wifi_config ap_conf;
@@ -88,6 +89,7 @@ struct wifi_manager {
 	struct wifimgr_mac_list mac_acl;
 	struct wifimgr_set_mac_acl set_acl;
 	struct wifimgr_ctrl_iface ap_ctrl;
+	struct wifimgr_delayed_work ap_autowork;
 
 	struct cmd_processor prcs;
 	struct evt_listener lsnr;
@@ -99,11 +101,28 @@ struct wifi_manager {
 	struct wifimgr_ap_event ap_evt;
 };
 
+#ifdef CONFIG_WIFIMGR_STA
 int wifimgr_sta_init(void *handle);
 void wifimgr_sta_exit(void *handle);
+#else
+#define wifimgr_sta_init(...)
+#define wifimgr_sta_exit(...)
+#endif
+
+#ifdef CONFIG_WIFIMGR_AP
 int wifimgr_ap_init(void *handle);
 void wifimgr_ap_exit(void *handle);
+#else
+#define wifimgr_ap_init(...)
+#define wifimgr_ap_exit(...)
+#endif
 
-int wifimgr_autorun_init(void);
+#ifdef CONFIG_WIFIMGR_AUTORUN
+int wifimgr_sta_autorun_init(void *handle);
+int wifimgr_ap_autorun_init(void *handle);
+#else
+#define wifimgr_sta_autorun_init(...)
+#define wifimgr_ap_autorun_init(...)
+#endif
 
 #endif


### PR DESCRIPTION
Use dedicated workqueue for timeout and autorun.

Signed-off-by: Keguang Zhang <keguang.zhang@unisoc.com>