### PR TITLE
drivers: wifi: uwp: Drop unnecessary returns

### DIFF
--- a/drivers/wifi/uwp/wifi_main.c
+++ b/drivers/wifi/uwp/wifi_main.c
@@ -705,17 +705,9 @@ static int uwp_init(struct device *dev)
 		wifi_irq_init();
 
 		k_sleep(400); /* FIXME: workaround */
-		ret = wifi_rf_init();
-		if (ret) {
-			LOG_ERR("wifi rf init failed.");
-			return ret;
-		}
+		wifi_rf_init();
 
-		ret = wifi_cmd_get_cp_info(priv);
-		if (ret) {
-			LOG_ERR("Get cp info failed.");
-			return ret;
-		}
+		wifi_cmd_get_cp_info(priv);
 
 		priv->initialized = true;
 	}


### PR DESCRIPTION
Drop retval check of wifi_rf_init and wifi_cmd_get_cp_info.
Two reasons:
1) There are already check inside them. It's easy to find if error happens.
2) Protect mulitple initializations from error
which might be tentative debug (parameters of get_cp_info cmd changed).
In this case, it should be allowed to go on because of nonfatal error.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>