### PR TITLE
drivers: wifi: uwp: Manage TX/RX share memory

### DIFF
--- a/drivers/wifi/uwp/CMakeLists.txt
+++ b/drivers/wifi/uwp/CMakeLists.txt
@@ -6,5 +6,6 @@ if(CONFIG_WIFI_UWP)
 	wifi_txrx.c
 	wifi_ipc.c
 	wifi_main.c
+	wifi_mem.c
     )
 endif()

--- a/drivers/wifi/uwp/Kconfig.uwp
+++ b/drivers/wifi/uwp/Kconfig.uwp
@@ -24,12 +24,26 @@ config WIFI_AP_DRV_NAME
 	string "SoftAP driver name"
 	default "WIFI_AP"
 
-config WIFI_UWP_MAX_RX_ADDR_NUM
-	int "Max rx addr num each time"
+config WIFI_UWP_MAX_RX_ADDR_COUNT
+	int "Max rx addr count each time"
+	default 32
+	help
+	  Max count CP can receive each time.
+
+config WIFI_UWP_NET_BUF_START_ADDR
+	int "Net buffer start address(decimal number)"
+	default 1702911
+
+config WIFI_UWP_TX_BUF_COUNT
+	int "TX buffer count"
 	default 32
 
-config WIFI_UWP_TOTAL_RX_ADDR_NUM
-	int "Total rx addr num"
-	default 120
+config WIFI_UWP_RX_BUF_COUNT
+	int "RX buffer count"
+	default 96
+
+config WIFI_UWP_NET_BUF_SIZE
+	int "Net buffer size"
+	default 1800
 
 endif

--- a/drivers/wifi/uwp/wifi_mem.c
+++ b/drivers/wifi/uwp/wifi_mem.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2018, UNISOC Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "wifi_mem.h"
+
+static wifi_slist_t tx_buf_list;
+static wifi_slist_t rx_buf_list;
+
+static struct k_mutex rx_buf_mutex;
+static struct k_mutex tx_buf_mutex;
+
+static void wifi_buf_list_clean(enum BUF_LIST_TYPE type)
+{
+	wifi_slist_t *buf_list;
+	struct k_mutex *buf_mutex;
+
+	if (type == TX_BUF_LIST) {
+		buf_list = &tx_buf_list;
+		buf_mutex = &tx_buf_mutex;
+	} else {
+		buf_list = &rx_buf_list;
+		buf_mutex = &rx_buf_mutex;
+	}
+
+	k_mutex_lock(buf_mutex, K_FOREVER);
+	while (wifi_buf_slist_get(buf_list)) {
+	}
+	k_mutex_unlock(buf_mutex);
+}
+
+static void wifi_buf_list_fill(enum BUF_LIST_TYPE type,
+		u32_t start_addr, u16_t buf_size, u8_t buf_count)
+{
+	wifi_slist_t *buf_list;
+	struct k_mutex *buf_mutex;
+
+	if (type == TX_BUF_LIST) {
+		buf_list = &tx_buf_list;
+		buf_mutex = &tx_buf_mutex;
+	} else {
+		buf_list = &rx_buf_list;
+		buf_mutex = &rx_buf_mutex;
+	}
+
+	for (int i = 0; i < buf_count; i++) {
+		k_mutex_lock(buf_mutex, K_FOREVER);
+		wifi_buf_slist_append(buf_list,
+				(wifi_snode_t *)(start_addr + i * buf_size));
+		k_mutex_unlock(buf_mutex);
+	}
+}
+
+void wifi_buf_list_refill(enum BUF_LIST_TYPE type)
+{
+	wifi_buf_list_clean(type);
+
+	if (type == TX_BUF_LIST) {
+		wifi_buf_list_fill(type, TX_START_ADDR,
+				CONFIG_WIFI_UWP_NET_BUF_SIZE,
+				CONFIG_WIFI_UWP_TX_BUF_COUNT);
+	} else {
+		wifi_buf_list_fill(type, RX_START_ADDR,
+				CONFIG_WIFI_UWP_NET_BUF_SIZE,
+				CONFIG_WIFI_UWP_RX_BUF_COUNT);
+	}
+}
+
+void wifi_buf_list_init(enum BUF_LIST_TYPE type)
+{
+	k_mutex_init(&tx_buf_mutex);
+	k_mutex_init(&rx_buf_mutex);
+
+	if (type == TX_BUF_LIST) {
+		wifi_buf_slist_init(&tx_buf_list);
+
+		wifi_buf_list_fill(type, TX_START_ADDR,
+				CONFIG_WIFI_UWP_NET_BUF_SIZE,
+				CONFIG_WIFI_UWP_TX_BUF_COUNT);
+	} else {
+		wifi_buf_slist_init(&rx_buf_list);
+
+		wifi_buf_list_fill(type, RX_START_ADDR,
+				CONFIG_WIFI_UWP_NET_BUF_SIZE,
+				CONFIG_WIFI_UWP_RX_BUF_COUNT);
+	}
+}
+
+u8_t *get_data_buf(enum BUF_LIST_TYPE type)
+{
+	u8_t *data_buf;
+	wifi_slist_t *buf_list;
+	struct k_mutex *buf_mutex;
+
+	if (type == TX_BUF_LIST) {
+		buf_list = &tx_buf_list;
+		buf_mutex = &tx_buf_mutex;
+	} else {
+		buf_list = &rx_buf_list;
+		buf_mutex = &rx_buf_mutex;
+	}
+
+	k_mutex_lock(buf_mutex, K_FOREVER);
+	data_buf = (u8_t *)wifi_buf_slist_get(buf_list);
+	k_mutex_unlock(buf_mutex);
+
+	return data_buf;
+}
+
+void recycle_data_buf(enum BUF_LIST_TYPE type, u8_t *data_buf)
+{
+	wifi_slist_t *buf_list;
+	struct k_mutex *buf_mutex;
+
+	if (type == TX_BUF_LIST) {
+		buf_list = &tx_buf_list;
+		buf_mutex = &tx_buf_mutex;
+	} else {
+		buf_list = &rx_buf_list;
+		buf_mutex = &rx_buf_mutex;
+	}
+
+	k_mutex_lock(buf_mutex, K_FOREVER);
+	wifi_buf_slist_append(buf_list, (wifi_snode_t *)data_buf);
+	k_mutex_unlock(buf_mutex);
+}

--- a/drivers/wifi/uwp/wifi_mem.h
+++ b/drivers/wifi/uwp/wifi_mem.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018, UNISOC Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __WIFI_MEM_H__
+#define __WIFI_MEM_H__
+
+
+#include <zephyr.h>
+
+#define TX_START_ADDR CONFIG_WIFI_UWP_NET_BUF_START_ADDR
+#define TX_BUF_TOTAL_SIZE \
+	(CONFIG_WIFI_UWP_TX_BUF_COUNT * CONFIG_WIFI_UWP_NET_BUF_SIZE)
+#define RX_START_ADDR (TX_START_ADDR + TX_BUF_TOTAL_SIZE)
+#define RX_BUF_TOTAL_SIZE \
+	(CONFIG_WIFI_UWP_RX_BUF_COUNT * CONFIG_WIFI_UWP_NET_BUF_SIZE)
+
+#define wifi_buf_slist_init(list) sys_slist_init(list)
+#define wifi_buf_slist_append(list, node) sys_slist_append(list, node)
+#define wifi_buf_slist_get(list) sys_slist_get(list)
+#define wifi_buf_slist_remove(list, node) sys_slist_find_and_remove(list, node)
+
+#define wifi_slist_t sys_slist_t
+#define wifi_snode_t sys_snode_t
+
+enum BUF_LIST_TYPE {
+	TX_BUF_LIST,
+	RX_BUF_LIST,
+};
+
+void wifi_buf_list_init(enum BUF_LIST_TYPE type);
+void wifi_buf_list_refill(enum BUF_LIST_TYPE type);
+u8_t *get_data_buf(enum BUF_LIST_TYPE type);
+void recycle_data_buf(enum BUF_LIST_TYPE type, u8_t *data_buf);
+
+
+#endif /* __WIFI_MEM_H__ */

--- a/drivers/wifi/uwp/wifi_txrx.h
+++ b/drivers/wifi/uwp/wifi_txrx.h
@@ -18,8 +18,7 @@
 
 #define ADDR_LEN (5)
 
-#define MAX_RX_ADDR_NUM CONFIG_WIFI_UWP_MAX_RX_ADDR_NUM
-#define TOTAL_RX_ADDR_NUM CONFIG_WIFI_UWP_TOTAL_RX_ADDR_NUM
+#define MAX_RX_ADDR_COUNT CONFIG_WIFI_UWP_MAX_RX_ADDR_COUNT
 
 #define SPRD_CP_DRAM_BEGIN (SPRD_AP_DRAM_BEGIN + SPRD_AP_CP_DRAM_MAP_BASE)
 #define SPRD_CP_DRAM_END (SPRD_AP_DRAM_END + SPRD_AP_CP_DRAM_MAP_BASE)
@@ -259,7 +258,7 @@ struct rx_empty_buff {
 	struct sprdwl_common_hdr common;
 	unsigned char type;
 	unsigned char num;
-	unsigned char addr[MAX_RX_ADDR_NUM][ADDR_LEN];
+	unsigned char addr[MAX_RX_ADDR_COUNT][ADDR_LEN];
 } __packed;
 
 /* 0 for cmd, 1 for event, 2 for data, 3 for mh data. */
@@ -309,7 +308,7 @@ enum {
 
 int wifi_tx_cmd(void *data, int len);
 int wifi_txrx_init(struct wifi_priv *priv);
-int wifi_tx_empty_buf(int num);
+int wifi_alloc_rx_buf(int num);
 int wifi_tx_data(void *data, int len);
 int wifi_release_rx_buf(void);
 


### PR DESCRIPTION
This share memory between AP and CP would not be cached.

Note: We must confirm the TX/RX buffer count and tweak the ram space.
That is, to decrease Zephyr ram.

Signed-off-by: Bub Wei bub.wei@unisoc.com