### PR TITLE
Tweak ram space

### DIFF
--- a/drivers/wifi/uwp/Kconfig.uwp
+++ b/drivers/wifi/uwp/Kconfig.uwp
@@ -31,19 +31,32 @@ config WIFI_UWP_MAX_RX_ADDR_COUNT
 	  Max count CP can receive each time.
 
 config WIFI_UWP_NET_BUF_START_ADDR
-	int "Net buffer start address(decimal number)"
-	default 1702911
+	hex "Net buffer start address"
+	default 0x1A0000
+	help
+	  Share buffer start address. Be careful to tweak this value.
+	  This address can't cover Zephyr's ram.
 
 config WIFI_UWP_TX_BUF_COUNT
 	int "TX buffer count"
-	default 32
+	default 30
+	range 10 30
+	help
+	  TX buffer count. Be careful to tweak this value.
 
 config WIFI_UWP_RX_BUF_COUNT
 	int "RX buffer count"
-	default 96
+	default 70
+	range 10 70
+	help
+	  RX buffer count. Be careful to tweak this value.
 
 config WIFI_UWP_NET_BUF_SIZE
 	int "Net buffer size"
 	default 1800
+	range 1700 1800
+	help
+	  Do not tweak this value if you are not sure how many
+	  bytes TX/RX buffer needs.
 
 endif

--- a/drivers/wifi/uwp/wifi_txrx.c
+++ b/drivers/wifi/uwp/wifi_txrx.c
@@ -156,7 +156,7 @@ int wifi_rx_complete_handle(struct wifi_priv *priv, void *data, int len)
 
 	if (i != 0) {
 		/* Allocate new empty buffer to cp. */
-		_wifi_alloc_rx_buf(1);
+		_wifi_alloc_rx_buf(i);
 	}
 
 	return 0;

--- a/dts/arm/unisoc/uwp5661.dtsi
+++ b/dts/arm/unisoc/uwp5661.dtsi
@@ -23,7 +23,7 @@
 	sram0: memory@100000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0x100000 DT_SIZE_K(832)>;
+		reg = <0x100000 DT_SIZE_K(640)>;
 	};
 
 	flash0: flash@200000 {


### PR DESCRIPTION
1)dts: arm: unisoc: Decrease Zephyr ram
   For TX/RX share buffer management in UNISOC code, decrease Zephyr ram from 832KB to 640KB.

2)drivers: wifi: uwp: Tweak TX/RX buf config
   Tweak start address from 0x19FBFF to 0x1A0000.
    Set limit for TX/RX count and buffer size.
