### PR TITLE
drivers: wifi: uwp: wifi_irq_init only on UWP5661

### DIFF
--- a/drivers/wifi/uwp/wifi_main.c
+++ b/drivers/wifi/uwp/wifi_main.c
@@ -688,7 +688,10 @@ static int uwp_init(struct device *dev)
 
 		wifi_cmdevt_init();
 		wifi_txrx_init(priv);
+
+#ifdef CONFIG_SOC_UWP5661
 		wifi_irq_init();
+#endif
 
 		k_sleep(400); /* FIXME: workaround */
 		wifi_rf_init();


### PR DESCRIPTION
Add macro define for wifi_irq_init, which only on UWP5661.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>