### PR TITLE
subsys: net: ip: Support ping times

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2786,6 +2786,7 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 	return -EOPNOTSUPP;
 #else
 	char *host;
+	int times = 1;
 	int ret;
 
 	ARG_UNUSED(argc);
@@ -2799,27 +2800,34 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 
 	shell_for_ping = shell;
 
-	if (IS_ENABLED(CONFIG_NET_IPV6)) {
-		ret = _ping_ipv6(shell, host);
-		if (!ret) {
-			goto wait_reply;
-		} else if (ret == -EIO) {
-			PR_WARNING("Cannot send IPv6 ping\n");
-			return -ENOEXEC;
-		}
+	if (argv[2]) {
+		times = atoi(argv[2]);
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV4)) {
-		ret = _ping_ipv4(shell, host);
-		if (ret) {
-			if (ret == -EIO) {
-				PR_WARNING("Cannot send IPv4 ping\n");
-			} else if (ret == -EINVAL) {
-				PR_WARNING("Invalid IP address\n");
+	while (times--) {
+		if (IS_ENABLED(CONFIG_NET_IPV6)) {
+			ret = _ping_ipv6(shell, host);
+			if (!ret) {
+				goto wait_reply;
+			} else if (ret == -EIO) {
+				PR_WARNING("Cannot send IPv6 ping\n");
+				return -ENOEXEC;
 			}
-
-			return -ENOEXEC;
 		}
+
+		if (IS_ENABLED(CONFIG_NET_IPV4)) {
+			ret = _ping_ipv4(shell, host);
+			if (ret) {
+				if (ret == -EIO) {
+					PR_WARNING("Cannot send IPv4 ping\n");
+				} else if (ret == -EINVAL) {
+					PR_WARNING("Invalid IP address\n");
+				}
+
+				return -ENOEXEC;
+			}
+		}
+		k_sleep(1000);
 	}
 
 wait_reply:


### PR DESCRIPTION
It's convenient to ping for times.
Usage:
    ping host [times]
For examples: ping 192.168.1.1 10, this will trigger ping for 10 times.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>