### PR TITLE
drivers: wifi: uwp: Remove unnecessary net_pkt_unref

### DIFF
--- a/drivers/wifi/uwp/main.c
+++ b/drivers/wifi/uwp/main.c
@@ -602,7 +602,6 @@ static int uwp_tx(struct device *dev, struct net_pkt *pkt)
 			total_len);
 
 	total_len += sizeof(struct tx_msdu_dscr);
-	net_pkt_unref(pkt);
 
 	LOG_DBG("wifi tx data: %d bytes", total_len);
 


### PR DESCRIPTION
Remove net_pkt_unref in uwp_tx, because
-if sent failed, net_if_tx would do it
-if sent succeeded, ethernet_send would do it.

Logs show:
[00:01:10.140,000] <err> net_pkt: *** ERROR ***
pkt 0x00113c78 is freed already by uwp_tx():605 (ethernet_send():598)

Signed-off-by: Bub Wei <bub.wei@unisoc.com>