### PR TITLE
dts: arm: unisoc: Fix incorrect description of wdg

### DIFF
--- a/dts/arm/unisoc/uwp5661.dtsi
+++ b/dts/arm/unisoc/uwp5661.dtsi
@@ -82,7 +82,7 @@
 			status = "disabled";
 		};
 
-		wdog: watchdog@40001000 {
+		wdog: watchdog@40010000 {
 			compatible = "unisoc,uwp-watchdog";
 			reg = <0x40010000 0x30>;
 			interrupts = <40 0>;

--- a/dts/arm/unisoc/uwp5662.dtsi
+++ b/dts/arm/unisoc/uwp5662.dtsi
@@ -92,7 +92,7 @@
 			status = "disabled";
 		};
 
-		wdog: watchdog@40001000 {
+		wdog: watchdog@40010000 {
 			compatible = "unisoc,uwp-watchdog";
 			reg = <0x40010000 0x30>;
 			interrupts = <40 0>;


### PR DESCRIPTION
Change the address description.
Warning (simple_bus_reg): /soc/watchdog@40001000:
simple-bus unit address format error, expected "40010000"

Signed-off-by: Bub Wei <bub.wei@unisoc.com>